### PR TITLE
Make Inverter and Logger variable to str

### DIFF
--- a/solarman_mqtt/config.yaml
+++ b/solarman_mqtt/config.yaml
@@ -41,8 +41,8 @@ schema:
   solarman_secret: str
   solarman_name: str
   solarman_station: int
-  solarman_inverter: int
-  solarman_logger: int
+  solarman_inverter: str
+  solarman_logger: str
   mqtt_broker: str
   mqtt_port: int
   mqtt_topic: str


### PR DESCRIPTION
Make solarman_inverter and solarman_logger variables to accept string input instead of integer only as there are some inverter and logger that uses string as their serial/id (ex., my inverter has an ID of SA3ESxxxxxx)